### PR TITLE
fix LH and LF calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # changelog for gcov2lcov
 
+## 1.0.2 [2020-04-25]
+
+* fix calculation of LH and LF values which led to wrong calculation of
+  test coverage in coveralls
+
 ## 1.0.1 [2020-04-25]
 
 * avoid duplicate DA records for same lines (see

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	go test ./... -coverprofile coverage.out
 	go tool cover -func coverage.out
 
-inttest: 
+inttest: build
 	./bin/gcov2lcov -infile testdata/coverage.out -outfile coverage.lcov
-	diff testdata/coverage_expected.lcov coverage.lcov
+	diff -y testdata/coverage_expected.lcov coverage.lcov
 

--- a/main.go
+++ b/main.go
@@ -112,7 +112,6 @@ func writeLcovRecord(filePath string, blocks []*block, w io.StringWriter) error 
 	// Loop over functions
 	// FNDA: stats,name ?
 
-	// Loop over lines
 	total := 0
 	covered := 0
 
@@ -123,9 +122,6 @@ func writeLcovRecord(filePath string, blocks []*block, w io.StringWriter) error 
 	for _, b := range blocks {
 		// For each line in a block we add an lcov entry and count the lines.
 		for i := b.startLine; i <= b.endLine; i++ {
-			if b.covered < 1 {
-				continue
-			}
 			coverMap[i] += b.covered
 		}
 	}
@@ -135,9 +131,13 @@ func writeLcovRecord(filePath string, blocks []*block, w io.StringWriter) error 
 	for _, line := range lines {
 		err = writer(err, "DA:"+strconv.Itoa(line)+","+strconv.Itoa(coverMap[line])+"\n")
 		total++
-		covered += coverMap[line]
+		if coverMap[line] > 0 {
+			covered++
+		}
 	}
 
+	// LH:<number of lines with a non-zero execution count>
+	// LF:<number of instrumented lines>
 	err = writer(err, "LF:"+strconv.Itoa(total)+"\n")
 	err = writer(err, "LH:"+strconv.Itoa(covered)+"\n")
 

--- a/main_test.go
+++ b/main_test.go
@@ -90,10 +90,11 @@ SF:main.go
 DA:6,1
 DA:7,1
 DA:8,1
+DA:9,0
 DA:10,2
 DA:11,2
-LF:5
-LH:7
+LF:6
+LH:5
 end_of_record
 `
 	assert.NoError(t, err)

--- a/testdata/coverage_expected.lcov
+++ b/testdata/coverage_expected.lcov
@@ -5,7 +5,8 @@ DA:46,1
 DA:47,1
 DA:48,1
 DA:49,1
+DA:50,0
 DA:58,1
-LF:6
+LF:7
 LH:6
 end_of_record


### PR DESCRIPTION
The values for 
```
 LH:<number of lines with a non-zero execution count>
 LF :<number of instrumented lines>
```
were calculated incorrectly,leading to wrong coverage reports.