### PR TITLE
Correct infile flag in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Usage of ./gcov2lcov:
 
 ```sh
 $ go test -coverprofile=coverage.out && \
-gcov2lcov -inputfile=coverage.out -outfile=coverage.lcov
+gcov2lcov -infile=coverage.out -outfile=coverage.lcov
 ```
 
 ## Build and Test


### PR DESCRIPTION
- Change flag for go cov source file from -inputfile to -infile instead