### PR TITLE
remove stripping of absolute path for SF key

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Usage of ./gcov2lcov:
     	go coverage file to read, default: <stdin>
   -outfile string
     	lcov file to write, default: <stdout>
+  -use-absolute-source-path
+    	use absolute paths for source file in lcov output, default: false
 ```
 
 ### Example

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestParseCoverage(t *testing.T) {
 github.com/jandelgado/gcov2lcov/main.go:6.14,8.3 2 1`
 
 	reader := strings.NewReader(cov)
-	res, err := parseCoverage(reader)
+	res, err := parseCoverage(reader, getCoverallsSourceFileName)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(res))
@@ -83,7 +84,7 @@ github.com/jandelgado/gcov2lcov/main.go:10.1,11.10 2 2`
 
 	in := strings.NewReader(cov)
 	out := bytes.NewBufferString("")
-	err := convertCoverage(in, out)
+	err := convertCoverage(in, out, getCoverallsSourceFileName)
 
 	expected := `TN:
 SF:main.go
@@ -99,4 +100,15 @@ end_of_record
 `
 	assert.NoError(t, err)
 	assert.Equal(t, expected, out.String())
+}
+
+func TestPathResolverFunc(t *testing.T) {
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	name := getCoverallsSourceFileName(pwd + "/main.go")
+	assert.Equal(t, "main.go", name)
+
+	name = getSourceFileName(pwd + "/main.go")
+	assert.Equal(t, pwd+"/main.go", name)
 }


### PR DESCRIPTION
The format wants an absolute path for the SF key as specified here under
the FILES section: http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php 
(and as I've just seen you have that in your README too)

Some programs will accept and work with relative paths with or without
./ but there's also a good chance to fail. Thus abiding by the spec is
the best idea.