### PR TITLE
Update go get in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ uses some parts of [goveralls](https://github.com/mattn/goveralls).
 ## Installation
 
 ```
-$ go get -u github.com/jandelgado/gcov2lcov
+$ go install github.com/jandelgado/gcov2lcov@latest
 ```
 
 ## Usage


### PR DESCRIPTION
With go 1.17, `go install` should be used instead of `go get -u...`