### PR TITLE
improve caching

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ type block struct {
 var vscDirs = []string{".git", ".hg", ".bzr", ".svn"}
 
 type cacheEntry struct {
-	file string
-	err  error
+	dir string
+	err error
 }
 
 var pkgCache = map[string]cacheEntry{}
@@ -47,16 +47,16 @@ func findFile(filePath string) (string, error) {
 	dir, file := filepath.Split(filePath)
 	var result cacheEntry
 	var ok bool
-	if result, ok = pkgCache[filePath]; !ok {
+	if result, ok = pkgCache[dir]; !ok {
 		pkg, err := build.Import(dir, ".", build.FindOnly)
 		if err == nil {
-			result = cacheEntry{filepath.Join(pkg.Dir, file), nil}
+			result = cacheEntry{filepath.Join(pkg.Dir), nil}
 		} else {
 			result = cacheEntry{"", err}
 		}
-		pkgCache[filePath] = result
+		pkgCache[dir] = result
 	}
-	return result.file, result.err
+	return filepath.Join(result.dir, file), result.err
 }
 
 // findRepositoryRoot finds the VCS root dir of a given dir


### PR DESCRIPTION
on a large project

before
`go run ../../gcov2lcov/main.go -infile coverage.out  265.15s user 166.02s system 228% cpu 3:09.06 total`

after
`go run ../../gcov2lcov/main.go -infile coverage.out  26.73s user 16.29s system 203% cpu 21.176 total`

Speed in crease about 10x