### PR TITLE
fix gitlab ci cache (setup-go)

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -11,12 +11,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
-    - name: Checkout code
-      uses: actions/checkout@v3
+        go-version: 1.21.x
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -32,13 +32,12 @@ jobs:
       matrix:
         goversion: ["1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
       - name: Install Go
-        if: success()
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.goversion }}
-      - name: Checkout code
-        uses: actions/checkout@v3
       - name: Run tests
         run: |
           go version
@@ -52,7 +51,6 @@ jobs:
         testversion: ["1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     steps:
       - name: Install Go
-        if: success()
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.buildversion }}
@@ -63,7 +61,6 @@ jobs:
           go version
           GO111MODULE=on make build-linux
       - name: Install Go
-        if: success()
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.testversion }}
@@ -81,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.21.x
       - name: build
         run: |
           go version

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -50,17 +50,17 @@ jobs:
         buildversion: ["1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
         testversion: ["1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     steps:
-      - name: Install Go
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go to build artifact
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.buildversion }}
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Build binary for inttest
+      - name: Build artifact for inttest
         run: |
           go version
           GO111MODULE=on make build-linux
-      - name: Install Go
+      - name: Install Go for inttest
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.testversion }}

--- a/.github/workflows/upload_assets.yml
+++ b/.github/workflows/upload_assets.yml
@@ -8,12 +8,12 @@ jobs:
     name: build binaries
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
-    - name: Checkout code
-      uses: actions/checkout@v3
+        go-version: 1.21.x
     - name: build
       run: |
         make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jandelgado/gcov2lcov
 
-go 1.19
+go 1.15
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
get rid of these warnings

```
inttest (1.15, 1.19)
Restore cache failed: Dependencies file is not found in /home/runner/work/gcov2lcov/gcov2lcov. Supported file pattern: go.sum
```